### PR TITLE
Send SendFramebufferUpdateRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The generic VNC protocol does not have an option to select display.
 Most VNC servers send whole desktop but some VNC servers for Windows have the ability to select a display.
 
 As a workaround of multi-display, the plugin provides settings `Skip update (left/right/top/bottom)`.
-Still the plugin receives the picture from the VNC server,
-these settings will discard an update-notification that goes to the graphics engine of OBS-Studio if all the updated region from the VNC-server is in the range of the values provided by these settings.
+these settings will avoid tranfering unnecessary picture.
 It is recommended to set the same values to the Crop settings in Scene Item Transform of your source.
 
 ## Furture plan

--- a/doc/properties.md
+++ b/doc/properties.md
@@ -49,7 +49,7 @@ Specifies when to connect to the server and when to disconnect from the server.
 - Disconnect at inactive: When the source is not shown on the Program, the connection will be disconnected.
 The default is Always.
 
-### Skip update
-VNC usually sends only the updated region.
-With this option, the source will ignore the notification that updates the frame outside the specified region.
-It will be useful to reduce frame transfer from CPU to GPU inside OBS Studio.
+### Skip update (left, right, top, bottom)
+This property requests the server to send only inside the specified area.
+It will help to reduce the amount of data transferred from the VNC server.
+It is recommended to set the same values to the Crop settings in Scene Item Transform of your source.

--- a/src/obs-vnc-source-main.c
+++ b/src/obs-vnc-source-main.c
@@ -93,10 +93,10 @@ static void vncsrc_update(void *data, obs_data_t *settings)
 	UPDATE_NOTIFY(src, int, qosdscp, dscp_updated, obs_data_get_int(settings, "qosdscp"));
 	src->config.connect_opt = obs_data_get_int(settings, "connect_opt");
 
-	src->config.skip_update_l = obs_data_get_int(settings, "skip_update_l");
-	src->config.skip_update_r = obs_data_get_int(settings, "skip_update_r");
-	src->config.skip_update_t = obs_data_get_int(settings, "skip_update_t");
-	src->config.skip_update_b = obs_data_get_int(settings, "skip_update_b");
+	UPDATE_NOTIFY(src, int, skip_update_l, skip_updated, obs_data_get_int(settings, "skip_update_l"));
+	UPDATE_NOTIFY(src, int, skip_update_r, skip_updated, obs_data_get_int(settings, "skip_update_r"));
+	UPDATE_NOTIFY(src, int, skip_update_t, skip_updated, obs_data_get_int(settings, "skip_update_t"));
+	UPDATE_NOTIFY(src, int, skip_update_b, skip_updated, obs_data_get_int(settings, "skip_update_b"));
 
 	pthread_mutex_unlock(&src->config_mutex);
 }

--- a/src/obs-vnc-source.h
+++ b/src/obs-vnc-source.h
@@ -80,6 +80,7 @@ struct vnc_source
 	volatile bool need_reconnect;
 	volatile bool encoding_updated;
 	volatile bool dscp_updated;
+	volatile bool skip_updated;
 	volatile bool running;
 	volatile long display_flags;
 


### PR DESCRIPTION
The properties `skip_update_*` will be taken for the arguments of
`SendFramebufferUpdateRequest` to reduce the amount of transferred data
from the server.

- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
