### PR TITLE
Improve stall while connection

### DIFF
--- a/doc/properties.md
+++ b/doc/properties.md
@@ -15,6 +15,10 @@ This field is available if the plugin is built with libvncserver having SASL.
 Password for VNC server.
 Plain password is stored in the setting file.
 
+### Connection timeout
+(Windows only)
+Specifies the timeout to connect to the VNC server.
+
 ### Color level
 Select the color level to use on the link.
 Default is 24-bit and available settings are 24-bit, 16-bit, 8-bit.

--- a/src/obs-vnc-source-main.c
+++ b/src/obs-vnc-source-main.c
@@ -137,6 +137,16 @@ static void vncsrc_get_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, "quality", 5);
 }
 
+bool reconnect_cb(obs_properties_t *props, obs_property_t *property, void *data)
+{
+	UNUSED_PARAMETER(props);
+	UNUSED_PARAMETER(property);
+	struct vnc_source *src = data;
+	vncsrc_request_reconnect(src);
+
+	return false;
+}
+
 static obs_properties_t *vncsrc_get_properties(void *unused)
 {
 	UNUSED_PARAMETER(unused);
@@ -156,6 +166,8 @@ static obs_properties_t *vncsrc_get_properties(void *unused)
 	prop = obs_properties_add_int(props, "rfb_timeout", obs_module_text("Connection timeout"), 1, 120, 1);
 	obs_property_int_set_suffix(prop, " s");
 #endif
+
+	obs_properties_add_button(props, "reconnect", obs_module_text("Reconnect"), reconnect_cb);
 
 	prop = obs_properties_add_list(props, "bpp", obs_module_text("Color level"), OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);

--- a/src/obs-vnc-source-main.c
+++ b/src/obs-vnc-source-main.c
@@ -63,20 +63,29 @@ static void vncsrc_update(void *data, obs_data_t *settings)
 		}                          \
 	} while (0)
 
+#define UPDATE_NOTIFY_RECONNECT(src, t, n, v)          \
+	do {                                           \
+		t x = (v);                             \
+		if (x != src->config.n) {              \
+			src->config.n = x;             \
+			vncsrc_request_reconnect(src); \
+		}                                      \
+	} while (0)
+
 	const char *host_name = obs_data_get_string(settings, "host_name");
 	if (host_name && (!src->config.host_name || strcmp(host_name, src->config.host_name))) {
 		BFREE_IF_NONNULL(src->config.host_name);
 		src->config.host_name = bstrdup(host_name);
-		src->need_reconnect = true;
+		vncsrc_request_reconnect(src);
 	}
 
-	UPDATE_NOTIFY(src, int, host_port, need_reconnect, (int)obs_data_get_int(settings, "host_port"));
+	UPDATE_NOTIFY_RECONNECT(src, int, host_port, (int)obs_data_get_int(settings, "host_port"));
 
 	const char *plain_passwd = obs_data_get_string(settings, "plain_passwd");
 	if (plain_passwd && (!src->config.plain_passwd || strcmp(plain_passwd, src->config.plain_passwd))) {
 		BFREE_IF_NONNULL(src->config.plain_passwd);
 		src->config.plain_passwd = bstrdup(plain_passwd);
-		src->need_reconnect = true;
+		vncsrc_request_reconnect(src);
 	}
 
 	src->config.rfb_timeout = (unsigned int)obs_data_get_int(settings, "rfb_timeout");
@@ -85,16 +94,16 @@ static void vncsrc_update(void *data, obs_data_t *settings)
 	const char *user_name = obs_data_get_string(settings, "user_name");
 	if (user_name && !*user_name) {
 		BFREE_IF_NONNULL(src->config.user_name);
-		src->need_reconnect = true;
+		vncsrc_request_reconnect(src);
 	}
 	else if (user_name && (!src->config.user_name || strcmp(user_name, src->config.user_name))) {
 		BFREE_IF_NONNULL(src->config.user_name);
 		src->config.user_name = bstrdup(user_name);
-		src->need_reconnect = true;
+		vncsrc_request_reconnect(src);
 	}
 #endif // LIBVNCSERVER_HAVE_SASL
 
-	UPDATE_NOTIFY(src, int, bpp, need_reconnect, (int)obs_data_get_int(settings, "bpp"));
+	UPDATE_NOTIFY_RECONNECT(src, int, bpp, (int)obs_data_get_int(settings, "bpp"));
 	UPDATE_NOTIFY(src, int, encodings, encoding_updated, (int)obs_data_get_int(settings, "encodings"));
 	UPDATE_NOTIFY(src, int, compress, encoding_updated, (int)obs_data_get_int(settings, "compress"));
 	UPDATE_NOTIFY(src, bool, jpeg, encoding_updated, obs_data_get_bool(settings, "jpeg"));

--- a/src/obs-vnc-source-thread.c
+++ b/src/obs-vnc-source-thread.c
@@ -228,6 +228,7 @@ static inline rfbClient *rfbc_start(struct vnc_source *src)
 	client->serverPort = src->config.host_port;
 	set_encodings_to_client(client, &src->config);
 	client->QoS_DSCP = src->config.qosdscp;
+	client->connectTimeout = src->config.rfb_timeout;
 
 	pthread_mutex_unlock(&src->config_mutex);
 

--- a/src/obs-vnc-source.h
+++ b/src/obs-vnc-source.h
@@ -102,6 +102,7 @@ struct vnc_source
 
 void vncsrc_thread_start(struct vnc_source *src);
 void vncsrc_thread_stop(struct vnc_source *src);
+void vncsrc_request_reconnect(struct vnc_source *src);
 
 #define BFREE_IF_NONNULL(x) \
 	if (x) {            \

--- a/src/obs-vnc-source.h
+++ b/src/obs-vnc-source.h
@@ -25,6 +25,7 @@ struct vncsrc_conig
 	char *user_name;
 #endif // LIBVNCSERVER_HAVE_SASL
 	char *plain_passwd;
+	unsigned int rfb_timeout;
 	int bpp; // bits per pixel; 8, 16, [32] only.
 	int encodings;
 	int compress;


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

- For Linux and macOS, uses a signal to interrupt libvncclient TCP connection.
- For Windows, decrease the timeout so that it is not so frustrating to wait the connection timeout.
- Add reconnect button

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->
Fedora 38

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
