### PR TITLE
Add a property to clear texture at disconnection

### DIFF
--- a/doc/properties.md
+++ b/doc/properties.md
@@ -53,6 +53,10 @@ Specifies when to connect to the server and when to disconnect from the server.
 - Disconnect at inactive: When the source is not shown on the Program, the connection will be disconnected.
 The default is Always.
 
+### Clear texture at disconnection
+If enabled, the texture will be cleared when the VNC connection is disconnected.
+If disabled, the texture will remain unchanged.
+
 ### Skip update (left, right, top, bottom)
 This property requests the server to send only inside the specified area.
 It will help to reduce the amount of data transferred from the VNC server.

--- a/src/obs-vnc-source-main.c
+++ b/src/obs-vnc-source-main.c
@@ -110,6 +110,7 @@ static void vncsrc_update(void *data, obs_data_t *settings)
 	UPDATE_NOTIFY(src, int, quality, encoding_updated, (int)obs_data_get_int(settings, "quality"));
 	UPDATE_NOTIFY(src, int, qosdscp, dscp_updated, (int)obs_data_get_int(settings, "qosdscp"));
 	src->config.connect_opt = (int)obs_data_get_int(settings, "connect_opt");
+	src->config.clear_at_disconnect = obs_data_get_bool(settings, "clear_at_disconnect");
 
 	UPDATE_NOTIFY(src, int, skip_update_l, skip_updated, (int)obs_data_get_int(settings, "skip_update_l"));
 	UPDATE_NOTIFY(src, int, skip_update_r, skip_updated, (int)obs_data_get_int(settings, "skip_update_r"));
@@ -200,6 +201,7 @@ static obs_properties_t *vncsrc_get_properties(void *unused)
 				  connect_at_active_disconnect_at_hidden);
 	obs_property_list_add_int(prop, obs_module_text("Connect at activated, disconnect at inactive"),
 				  connect_at_active_disconnect_at_inactive);
+	obs_properties_add_bool(props, "clear_at_disconnect", obs_module_text("Clear texture at disconnection"));
 
 	obs_properties_add_int(props, "skip_update_l", obs_module_text("Skip update (left)"), 0, 32767, 1);
 	obs_properties_add_int(props, "skip_update_r", obs_module_text("Skip update (right)"), 0, 32767, 1);

--- a/src/obs-vnc-source.h
+++ b/src/obs-vnc-source.h
@@ -40,6 +40,7 @@ struct vncsrc_conig
 		connect_at_active_disconnect_at_hidden = 2 + 4,
 		connect_at_active_disconnect_at_inactive = 2 + 8,
 	} connect_opt;
+	bool clear_at_disconnect;
 
 	int skip_update_l, skip_update_r, skip_update_t, skip_update_b;
 };


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Add a property "Clear texture at disconnection".

When the property is enabled, calls `obs_source_output_video` with `frame` = `NULL` so that the texture will be deactivated.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->
Checked the texture size became 0x0 when the connection was disconnected.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.

Fix #34.
