### PR TITLE
Ensure bmalloc always takes positive size

### DIFF
--- a/src/obs-vnc-source-thread.c
+++ b/src/obs-vnc-source-thread.c
@@ -127,6 +127,12 @@ static rfbBool vnc_malloc_fb(rfbClient *client)
 
 	debug("vnc_malloc_fb width=%d height=%d\n", client->width, client->height);
 
+	if (client->width <= 0 || client->height <= 0) {
+		blog(LOG_ERROR, "vnc_malloc_fb gets 0-length geometry %dx%d", client->width, client->height);
+		client->frameBuffer = NULL;
+		return FALSE;
+	}
+
 	src->frame.width = client->width;
 	src->frame.height = client->height;
 	set_updateRect(src, client);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

OBS Studio >= 31.0.0 requires `bmalloc` takes positive size, or it will crash.

Though the case probably won't hit, it would be safe to check the size before calling `bmalloc`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

I have not tested yet.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
